### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/galaga/undersea_galaga.html
+++ b/galaga/undersea_galaga.html
@@ -269,10 +269,21 @@ body.light #galaga-btn:hover {
       localStorage.setItem('underseaGalagaHighScores', JSON.stringify(highScores));
     }
 
+    // Escape HTML special characters to prevent XSS
+    function escapeHTML(str) {
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/`/g, '&#96;');
+    }
+
     function updateScoreboard() {
       let html = '<table><tr><th>Rank</th><th>Initials</th><th>Score</th></tr>';
       highScores.forEach((entry, i) => {
-        html += `<tr><td>${i + 1}</td><td>${entry.name}</td><td>${entry.score}</td></tr>`;
+        html += `<tr><td>${i + 1}</td><td>${escapeHTML(entry.name)}</td><td>${entry.score}</td></tr>`;
       });
       html += '</table>';
       scoreboardDiv.innerHTML = html;


### PR DESCRIPTION
Potential fix for [https://github.com/mikeykhill/Website/security/code-scanning/1](https://github.com/mikeykhill/Website/security/code-scanning/1)

To fix this vulnerability, we need to ensure that any user-supplied data (in this case, the initials) is properly escaped before being inserted into the DOM as HTML. The best way to do this is to escape special HTML characters (`&`, `<`, `>`, `"`, `'`, and `` ` ``) in the user input before interpolating it into the HTML string. This can be done by defining a helper function (e.g., `escapeHTML`) that replaces these characters with their corresponding HTML entities. We should use this function when constructing the scoreboard HTML, specifically when outputting `entry.name`. The changes should be made in the `updateScoreboard` function, and the `escapeHTML` function should be defined in the same script block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
